### PR TITLE
Attached comments

### DIFF
--- a/TabCode.cabal
+++ b/TabCode.cabal
@@ -1,5 +1,5 @@
 name: TabCode
-version: 0.1
+version: 1.2.0
 synopsis: A parser for the Tabcode lute tablature language
 author: Richard Lewis
 license: GPL

--- a/src/TabCode.hs
+++ b/src/TabCode.hs
@@ -159,7 +159,7 @@ duplicateCoursesInNotes ns =
   where cs = coursesFromNotes ns
 
 duplicateCourses :: TabWord -> Bool
-duplicateCourses (Chord _ _ _ ns) = duplicateCoursesInNotes ns
+duplicateCourses (Chord _ _ _ ns _) = duplicateCoursesInNotes ns
 duplicateCourses _ = False
 
 data Counting
@@ -206,26 +206,30 @@ data MeterSign
   | HorizontalMeterSign Mensuration Mensuration
   deriving (Eq, Show)
 
+data Comment
+  = Comment String
+  deriving (Eq, Show)
+
 data TabWord
-  = Chord Line Column (Maybe RhythmSign) [Note]
-  | Rest Line Column RhythmSign
-  | BarLine Line Column Bar
-  | Meter Line Column MeterSign
-  | Comment Line Column String
-  | SystemBreak Line Column
-  | PageBreak Line Column
+  = Chord Line Column (Maybe RhythmSign) [Note] (Maybe Comment)
+  | Rest Line Column RhythmSign (Maybe Comment)
+  | BarLine Line Column Bar (Maybe Comment)
+  | Meter Line Column MeterSign (Maybe Comment)
+  | CommentWord Line Column Comment
+  | SystemBreak Line Column (Maybe Comment)
+  | PageBreak Line Column (Maybe Comment)
   | Invalid String Line Column String
   deriving (Eq, Show)
 
 twPos :: TabWord -> (Line, Column)
-twPos (Chord l c _ _)   = (l, c)
-twPos (Rest l c _)      = (l, c)
-twPos (BarLine l c _)   = (l, c)
-twPos (Meter l c _)     = (l, c)
-twPos (Comment l c _)   = (l, c)
-twPos (SystemBreak l c) = (l, c)
-twPos (PageBreak l c)   = (l, c)
-twPos (Invalid _ l c _) = (l, c)
+twPos (Chord l c _ _ _)      = (l, c)
+twPos (Rest l c _ _)         = (l, c)
+twPos (BarLine l c _ _)      = (l, c)
+twPos (Meter l c _ _)        = (l, c)
+twPos (CommentWord l c _)    = (l, c)
+twPos (SystemBreak l c _)    = (l, c)
+twPos (PageBreak l c _)      = (l, c)
+twPos (Invalid _ l c _)      = (l, c)
 
 twLine :: TabWord -> Line
 twLine = fst . twPos
@@ -237,7 +241,7 @@ coursesFromNotes :: [Note] -> [Course]
 coursesFromNotes ns = map (\(Note crs _ _ _ _ _) -> crs) ns
 
 courses :: TabWord -> [Course]
-courses (Chord _ _ _ ns) = coursesFromNotes ns
+courses (Chord _ _ _ ns _) = coursesFromNotes ns
 courses _ = []
 
 data Rule = Rule String String deriving (Eq, Show)

--- a/src/TabCode/MEI.hs
+++ b/src/TabCode/MEI.hs
@@ -109,34 +109,34 @@ anyMeasure = (try measureSng) <|> (try measureDbl) <|> (try measureRptEnd) <|> (
 barLineSng :: TabWordsToMEI
 barLineSng = tokenPrim show updatePos getBarLine
   where
-    getBarLine bl@(BarLine l c (SingleBar Nothing Nothing NotDashed _)) = Just $ MEIBarLine ( atForm "single" ) []
+    getBarLine bl@(BarLine l c (SingleBar Nothing Nothing NotDashed _) cmt) = Just $ MEIBarLine ( atForm "single" ) (attachedComment cmt)
     getBarLine _ = Nothing
 
 barLineDbl :: TabWordsToMEI
 barLineDbl = tokenPrim show updatePos getBarLine
   where
-    getBarLine bl@(BarLine l c (DoubleBar Nothing Nothing NotDashed _)) = Just $ MEIBarLine ( atForm "double" ) []
+    getBarLine bl@(BarLine l c (DoubleBar Nothing Nothing NotDashed _) cmt) = Just $ MEIBarLine ( atForm "double" ) (attachedComment cmt)
     getBarLine _ = Nothing
 
 barLineRptL :: TabWordsToMEI
 barLineRptL = tokenPrim show updatePos getBarLine
   where
-    getBarLine bl@(BarLine l c (SingleBar (Just RepeatLeft) Nothing NotDashed _)) = Just $ MEIBarLine ( atForm "single-rptend" ) []
-    getBarLine bl@(BarLine l c (DoubleBar (Just RepeatLeft) Nothing NotDashed _)) = Just $ MEIBarLine ( atForm "double-rptend" ) []
+    getBarLine bl@(BarLine l c (SingleBar (Just RepeatLeft) Nothing NotDashed _) cmt) = Just $ MEIBarLine ( atForm "single-rptend" ) (attachedComment cmt)
+    getBarLine bl@(BarLine l c (DoubleBar (Just RepeatLeft) Nothing NotDashed _) cmt) = Just $ MEIBarLine ( atForm "double-rptend" ) (attachedComment cmt)
     getBarLine _ = Nothing
 
 barLineRptR :: TabWordsToMEI
 barLineRptR = tokenPrim show updatePos getBarLine
   where
-    getBarLine bl@(BarLine l c (SingleBar (Just RepeatRight) Nothing NotDashed _)) = Just $ MEIBarLine ( atForm "single-rptstart" ) []
-    getBarLine bl@(BarLine l c (DoubleBar (Just RepeatRight) Nothing NotDashed _)) = Just $ MEIBarLine ( atForm "double-rptstart" ) []
+    getBarLine bl@(BarLine l c (SingleBar (Just RepeatRight) Nothing NotDashed _) cmt) = Just $ MEIBarLine ( atForm "single-rptstart" ) (attachedComment cmt)
+    getBarLine bl@(BarLine l c (DoubleBar (Just RepeatRight) Nothing NotDashed _) cmt) = Just $ MEIBarLine ( atForm "double-rptstart" ) (attachedComment cmt)
     getBarLine _ = Nothing
 
 barLineRptB :: TabWordsToMEI
 barLineRptB = tokenPrim show updatePos getBarLine
   where
-    getBarLine bl@(BarLine l c (SingleBar (Just RepeatBoth) Nothing NotDashed _)) = Just $ MEIBarLine ( atForm "single-rptboth" ) []
-    getBarLine bl@(BarLine l c (DoubleBar (Just RepeatBoth) Nothing NotDashed _)) = Just $ MEIBarLine ( atForm "double-rptboth" ) []
+    getBarLine bl@(BarLine l c (SingleBar (Just RepeatBoth) Nothing NotDashed _) cmt) = Just $ MEIBarLine ( atForm "single-rptboth" ) (attachedComment cmt)
+    getBarLine bl@(BarLine l c (DoubleBar (Just RepeatBoth) Nothing NotDashed _) cmt) = Just $ MEIBarLine ( atForm "double-rptboth" ) (attachedComment cmt)
     getBarLine _ = Nothing
 
 barLine :: TabWordsToMEI
@@ -172,21 +172,21 @@ chordLike getChord = do
 chord :: TabWordsToMEI
 chord = chordLike getChord
   where
-    getChord st ch@(Chord l c (Just r) ns) = Just (newState, meiChord)
+    getChord st ch@(Chord l c (Just r) ns cmt) = Just (newState, meiChord)
       where
         newState = st { stRhythmGlyphId = atXmlIdNext $ stRhythmGlyphId st
                       , stNoteId = mutateAttr (pack "xml:id") (incIntAttr $ length ns) (stNoteId st)
                       }
-        meiChord = MEIChord attributes ( rhythmSign <> notes )
+        meiChord = MEIChord attributes ( rhythmSign <> notes <> (attachedComment cmt) )
         attributes = (stChordId st) <> replaceAttrs (stChord st) (atDur r)
         rhythmSign = elRhythmSign (stRhythmGlyphId st) r
         notes = concat $ (\(note, idx) -> (elNote (atXmlId "n" idx) (stRules st) note)) <$> notesWithIds
         notesWithIds = zip ns [(xmlIdNumber $ (stNoteId st))..]
 
-    getChord st ch@(Chord l c Nothing ns) = Just (newState, meiChord)
+    getChord st ch@(Chord l c Nothing ns cmt) = Just (newState, meiChord)
       where
         newState = st { stNoteId = mutateAttr (pack "xml:id") (incIntAttr $ length ns) (stNoteId st) }
-        meiChord = MEIChord attributes notes
+        meiChord = MEIChord attributes ( notes <> (attachedComment cmt) )
         attributes = (stChordId st) <> (stChord st)
         notes = concat $ (\(note, idx) -> (elNote (atXmlId "n" idx) (stRules st) note)) <$> notesWithIds
         notesWithIds = zip ns [(xmlIdNumber $ (stNoteId st))..]
@@ -196,12 +196,12 @@ chord = chordLike getChord
 chordCompound :: TabWordsToMEI
 chordCompound = chordLike getChord
   where
-    getChord st ch@(Chord l c (Just r@(RhythmSign _ Compound _ _)) ns) = Just (newState, meiChord)
+    getChord st ch@(Chord l c (Just r@(RhythmSign _ Compound _ _)) ns cmt) = Just (newState, meiChord)
       where
         newState = st { stRhythmGlyphId = atXmlIdNext $ stRhythmGlyphId st
                       , stNoteId = mutateAttr (pack "xml:id") (incIntAttr $ length ns) (stNoteId st)
                       }
-        meiChord = MEIChord attributes ( rhythmSign <> notes )
+        meiChord = MEIChord attributes ( rhythmSign <> notes <> (attachedComment cmt) )
         attributes = (stChordId st) <> replaceAttrs (stChord st) (atDur r)
         rhythmSign = elRhythmSign (stRhythmGlyphId st) r
         notes = concat $ (\(note, idx) -> (elNote (atXmlId "n" idx) (stRules st) note)) <$> notesWithIds
@@ -212,10 +212,10 @@ chordCompound = chordLike getChord
 chordNoRS :: TabWordsToMEI
 chordNoRS = chordLike getChord
   where
-    getChord st ch@(Chord l c Nothing ns) = Just (newState, meiChord)
+    getChord st ch@(Chord l c Nothing ns cmt) = Just (newState, meiChord)
       where
         newState = st { stNoteId = mutateAttr (pack "xml:id") (incIntAttr $ length ns) (stNoteId st) }
-        meiChord = MEIChord attributes notes
+        meiChord = MEIChord attributes ( notes <> (attachedComment cmt) )
         attributes = (stChordId st) <> (stChord st)
         notes = concat $ (\(note, idx) -> (elNote (atXmlId "n" idx) (stRules st) note)) <$> notesWithIds
         notesWithIds = zip ns [(xmlIdNumber $ (stNoteId st))..]
@@ -230,16 +230,16 @@ rest = do
   return r
 
   where
-    getRest st re@(Rest l c (RhythmSign Fermata _ _ _)) = Just (newState, meiFermata)
+    getRest st re@(Rest l c (RhythmSign Fermata _ _ _) cmt) = Just (newState, meiFermata)
       where
         newState = st { stRestId = atXmlIdNext $ stRestId st }
-        meiFermata = MEIFermata (stRestId st) []
+        meiFermata = MEIFermata (stRestId st) (attachedComment cmt)
 
-    getRest st re@(Rest l c r) = Just (newState, meiRest)
+    getRest st re@(Rest l c r cmt) = Just (newState, meiRest)
       where
         newState = st { stRhythmGlyphId = atXmlIdNext $ stRhythmGlyphId st
                       , stRestId = atXmlIdNext $ stRestId st }
-        meiRest = MEIRest ( (stRestId st) <> atDur r ) $ ( elRhythmSign (stRhythmGlyphId st) r )
+        meiRest = MEIRest ( (stRestId st) <> atDur r ) $ ( (elRhythmSign (stRhythmGlyphId st) r) <> (attachedComment cmt) )
 
     getRest _ _ = Nothing
 
@@ -251,29 +251,29 @@ meter = do
   putState $ newSt
   return m
   where
-    getMeter atts me@(Meter l c m) = case m of
+    getMeter atts me@(Meter l c m cmt) = case m of
       (SingleMeterSign PerfectMajor)
-        -> Just $ MEIStaffDef ( atts <> atProlation 3 <> atTempus 3 ) [ MEIMensur ( atSign 'O' <> atDot True ) [] ]
+        -> Just $ MEIStaffDef ( atts <> atProlation 3 <> atTempus 3 ) [ MEIMensur ( atSign 'O' <> atDot True ) (attachedComment cmt) ]
       (SingleMeterSign PerfectMinor)
-        -> Just $ MEIStaffDef ( atts <> atProlation 3 <> atTempus 2 ) [ MEIMensur ( atSign 'O' <> atDot False ) [] ]
+        -> Just $ MEIStaffDef ( atts <> atProlation 3 <> atTempus 2 ) [ MEIMensur ( atSign 'O' <> atDot False ) (attachedComment cmt) ]
       (SingleMeterSign ImperfectMajor)
-        -> Just $ MEIStaffDef ( atts <> atProlation 2 <> atTempus 3 ) [ MEIMensur ( atSign 'C' <> atDot True ) [] ]
+        -> Just $ MEIStaffDef ( atts <> atProlation 2 <> atTempus 3 ) [ MEIMensur ( atSign 'C' <> atDot True ) (attachedComment cmt) ]
       (SingleMeterSign ImperfectMinor)
-        -> Just $ MEIStaffDef ( atts <> atProlation 2 <> atTempus 2 ) [ MEIMensur ( atSign 'C' <> atDot False ) [] ]
+        -> Just $ MEIStaffDef ( atts <> atProlation 2 <> atTempus 2 ) [ MEIMensur ( atSign 'C' <> atDot False ) (attachedComment cmt) ]
       (SingleMeterSign HalfPerfectMajor)
-        -> Just $ MEIStaffDef ( atts <> atProlation 3 <> atTempus 3 <> atSlash 1 ) [ MEIMensur ( atSign 'O' <> atDot True <> atCut 1 ) [] ]
+        -> Just $ MEIStaffDef ( atts <> atProlation 3 <> atTempus 3 <> atSlash 1 ) [ MEIMensur ( atSign 'O' <> atDot True <> atCut 1 ) (attachedComment cmt) ]
       (SingleMeterSign HalfPerfectMinor)
-        -> Just $ MEIStaffDef ( atts <> atProlation 3 <> atTempus 2 <> atSlash 1 ) [ MEIMensur ( atSign 'O' <> atDot False <> atCut 1 ) [] ]
+        -> Just $ MEIStaffDef ( atts <> atProlation 3 <> atTempus 2 <> atSlash 1 ) [ MEIMensur ( atSign 'O' <> atDot False <> atCut 1 ) (attachedComment cmt) ]
       (SingleMeterSign HalfImperfectMajor)
-        -> Just $ MEIStaffDef ( atts <> atProlation 2 <> atTempus 3 <> atSlash 1 ) [ MEIMensur ( atSign 'C' <> atDot True <> atCut 1 ) [] ]
+        -> Just $ MEIStaffDef ( atts <> atProlation 2 <> atTempus 3 <> atSlash 1 ) [ MEIMensur ( atSign 'C' <> atDot True <> atCut 1 ) (attachedComment cmt) ]
       (SingleMeterSign HalfImperfectMinor)
-        -> Just $ MEIStaffDef ( atts <> atProlation 2 <> atTempus 2 <> atSlash 1 ) [ MEIMensur ( atSign 'C' <> atDot False <> atCut 1 ) [] ]
+        -> Just $ MEIStaffDef ( atts <> atProlation 2 <> atTempus 2 <> atSlash 1 ) [ MEIMensur ( atSign 'C' <> atDot False <> atCut 1 ) (attachedComment cmt) ]
       (VerticalMeterSign (Beats n) (Beats b))
-        -> Just $ MEIStaffDef ( atts <> atNumDef n <> atNumbaseDef b ) [ MEIMeterSig ( atCount n <> atUnit b ) [] ]
+        -> Just $ MEIStaffDef ( atts <> atNumDef n <> atNumbaseDef b ) [ MEIMeterSig ( atCount n <> atUnit b ) (attachedComment cmt) ]
       (HorizontalMeterSign (Beats n) (Beats b))
-        -> Just $ MEIStaffDef ( atts <> atNumDef n <> atNumbaseDef b ) [ MEIMeterSig ( atCount n <> atUnit b ) [] ]
+        -> Just $ MEIStaffDef ( atts <> atNumDef n <> atNumbaseDef b ) [ MEIMeterSig ( atCount n <> atUnit b ) (attachedComment cmt) ]
       (SingleMeterSign (Beats 3))
-        -> Just $ MEIStaffDef ( atts <> atTempus 3 ) []
+        -> Just $ MEIStaffDef ( atts <> atTempus 3 ) (attachedComment cmt)
       _
         -> Just $ XMLComment $ pack $ " tc2mei: Un-implemented mensuration sign: " ++ (show m) ++ " "
 
@@ -282,20 +282,24 @@ meter = do
 systemBreak :: TabWordsToMEI
 systemBreak = tokenPrim show updatePos getSystemBreak
   where
-    getSystemBreak re@(SystemBreak l c) = Just $ MEISystemBreak noMEIAttrs []
-    getSystemBreak _                    = Nothing
+    getSystemBreak re@(SystemBreak l c cmt) = Just $ MEISystemBreak noMEIAttrs (attachedComment cmt)
+    getSystemBreak _ = Nothing
 
 pageBreak :: TabWordsToMEI
 pageBreak = tokenPrim show updatePos getPageBreak
   where
-    getPageBreak re@(PageBreak l c) = Just $ MEIPageBreak noMEIAttrs []
-    getPageBreak _                  = Nothing
+    getPageBreak re@(PageBreak l c cmt) = Just $ MEIPageBreak noMEIAttrs (attachedComment cmt)
+    getPageBreak _ = Nothing
 
 comment :: TabWordsToMEI
 comment = tokenPrim show updatePos getComment
   where
-    getComment re@(Comment l c cmt) = Just $ XMLComment $ pack cmt
-    getComment _                    = Nothing
+    getComment re@(CommentWord l c (Comment cmt)) = Just $ XMLComment $ pack cmt
+    getComment _ = Nothing
+
+attachedComment :: Maybe Comment -> [MEI]
+attachedComment (Just (Comment cmt)) = [ XMLComment $ pack cmt ]
+attachedComment Nothing = []
 
 invalid :: TabWordsToMEI
 invalid = tokenPrim show updatePos getInvalid

--- a/tests/MEITests.hs
+++ b/tests/MEITests.hs
@@ -161,6 +161,22 @@ measures =
     "c1\n|\nc1\n|\n" $ asMEI "<measure xml:id='m1' n='1'><staff n='1' def='#staff-0'><layer n='1'><chord xml:id='c1'><note xml:id='n1' tab.course='1' tab.fret='2'/></chord></layer></staff></measure><measure xml:id='m2' n='2'><staff n='1' def='#staff-0'><layer n='1'><chord xml:id='c2'><note xml:id='n2' tab.course='1' tab.fret='2'/></chord></layer></staff></measure>"
   ]
 
+comments :: [Test]
+comments =
+  [ Test $ mkMEITest
+    "Qa1{foo}" $ asStaff "#staff-0" "<chord xml:id='c1' dur='4'><rhythmGlyph xml:id='rg1' symbol='Q'/><note xml:id='n1' tab.course='1' tab.fret='0'/><!--foo--></chord>"
+  , Test $ mkMEITest
+    "Qa1 {foo}" $ asStaff "#staff-0" "<chord xml:id='c1' dur='4'><rhythmGlyph xml:id='rg1' symbol='Q'/><note xml:id='n1' tab.course='1' tab.fret='0'/><!--foo--></chord>"
+  , Test $ mkMEITest
+    "Qa1\n{foo}" $ asStaff "#staff-0" "<chord xml:id='c1' dur='4'><rhythmGlyph xml:id='rg1' symbol='Q'/><note xml:id='n1' tab.course='1' tab.fret='0'/></chord><!--foo-->"
+  , Test $ mkMEITest
+    "Q{foo}" $ asStaff "#staff-0" "<rest xml:id='r1' dur='4'><rhythmGlyph xml:id='rg1' symbol='Q'/><!--foo--></rest>"
+  , Test $ mkMEITest
+    "|{foo}" $ asStaff "#staff-0" "<barLine form='single' n='1' xml:id='bl1'><!--foo--></barLine>"
+  , Test $ mkMEITest
+    "M(O){foo}" $ asStaff "#staff-1" "<staffDef xml:id='staff-1' prolatio='3' tempus='2'><mensur sign='O' dot='false'><!--foo--></mensur></staffDef>"
+  ]
+
 tests :: IO [Test]
 tests = return $ meterSigns
   ++ rests
@@ -168,3 +184,4 @@ tests = return $ meterSigns
   ++ phrases
   ++ barLines
   ++ measures
+  ++ comments

--- a/tests/ParseTests.hs
+++ b/tests/ParseTests.hs
@@ -336,4 +336,10 @@ comments =
   , Test $ mkParseTest "{}" (Comment 1 1 "")
   , Test $ mkParseTest "{\n}" (Comment 1 1 "\n")
   , Test $ mkParseTest "{foo\nbar}" (Comment 1 1 "foo\nbar")
+  , Test $ mkParseTest "{foo}a1c3" (Chord 1 1 Nothing [ Note One A (Nothing, Nothing) Nothing Nothing Nothing
+                                                      , Note Three C (Nothing, Nothing) Nothing Nothing Nothing ])
+  , Test $ mkParseTest "a1{foo}c3" (Chord 1 1 Nothing [ Note One A (Nothing, Nothing) Nothing Nothing Nothing
+                                                      , Note Three C (Nothing, Nothing) Nothing Nothing Nothing ])
+  , Test $ mkParseTest "a1c3{foo}" (Chord 1 1 Nothing [ Note One A (Nothing, Nothing) Nothing Nothing Nothing
+                                                      , Note Three C (Nothing, Nothing) Nothing Nothing Nothing ])
   ]

--- a/tests/ParseTests.hs
+++ b/tests/ParseTests.hs
@@ -85,140 +85,141 @@ tests = return $ meterSigns
   ++ fingerings
   ++ ornaments
   ++ comments
+  ++ structuredComments
 
 meterSigns :: [Test]
 meterSigns =
-  [ Test $ mkParseTest "M(O.)\n" (Meter 1 1 (SingleMeterSign PerfectMajor))
-  , Test $ mkParseTest "M(O)\n" (Meter 1 1 (SingleMeterSign PerfectMinor))
-  , Test $ mkParseTest "M(C.)\n" (Meter 1 1 (SingleMeterSign ImperfectMajor))
-  , Test $ mkParseTest "M(C)\n" (Meter 1 1 (SingleMeterSign ImperfectMinor))
-  , Test $ mkParseTest "M(O/.)\n" (Meter 1 1 (SingleMeterSign HalfPerfectMajor))
-  , Test $ mkParseTest "M(O/)\n" (Meter 1 1 (SingleMeterSign HalfPerfectMinor))
-  , Test $ mkParseTest "M(C/.)\n" (Meter 1 1 (SingleMeterSign HalfImperfectMajor))
-  , Test $ mkParseTest "M(C/)\n" (Meter 1 1 (SingleMeterSign HalfImperfectMinor))
-  , Test $ mkParseTest "M(D.)\n" (Meter 1 1 (SingleMeterSign HalfImperfectMajor))
-  , Test $ mkParseTest "M(D)\n" (Meter 1 1 (SingleMeterSign HalfImperfectMinor))
-  , Test $ mkParseTest "M(3)\n" (Meter 1 1 (SingleMeterSign (Beats 3)))
-  , Test $ mkParseTest "M(4:4)\n" (Meter 1 1 (VerticalMeterSign (Beats 4) (Beats 4)))
-  , Test $ mkParseTest "M(4;4)\n" (Meter 1 1 (HorizontalMeterSign (Beats 4) (Beats 4)))
+  [ Test $ mkParseTest "M(O.)\n" (Meter 1 1 (SingleMeterSign PerfectMajor) Nothing)
+  , Test $ mkParseTest "M(O)\n" (Meter 1 1 (SingleMeterSign PerfectMinor) Nothing)
+  , Test $ mkParseTest "M(C.)\n" (Meter 1 1 (SingleMeterSign ImperfectMajor) Nothing)
+  , Test $ mkParseTest "M(C)\n" (Meter 1 1 (SingleMeterSign ImperfectMinor) Nothing)
+  , Test $ mkParseTest "M(O/.)\n" (Meter 1 1 (SingleMeterSign HalfPerfectMajor) Nothing)
+  , Test $ mkParseTest "M(O/)\n" (Meter 1 1 (SingleMeterSign HalfPerfectMinor) Nothing)
+  , Test $ mkParseTest "M(C/.)\n" (Meter 1 1 (SingleMeterSign HalfImperfectMajor) Nothing)
+  , Test $ mkParseTest "M(C/)\n" (Meter 1 1 (SingleMeterSign HalfImperfectMinor) Nothing)
+  , Test $ mkParseTest "M(D.)\n" (Meter 1 1 (SingleMeterSign HalfImperfectMajor) Nothing)
+  , Test $ mkParseTest "M(D)\n" (Meter 1 1 (SingleMeterSign HalfImperfectMinor) Nothing)
+  , Test $ mkParseTest "M(3)\n" (Meter 1 1 (SingleMeterSign (Beats 3)) Nothing)
+  , Test $ mkParseTest "M(4:4)\n" (Meter 1 1 (VerticalMeterSign (Beats 4) (Beats 4)) Nothing)
+  , Test $ mkParseTest "M(4;4)\n" (Meter 1 1 (HorizontalMeterSign (Beats 4) (Beats 4)) Nothing)
   ]
 
 rests :: [Test]
 rests =
-  [ Test $ mkParseTest "F\n" (Rest 1 1 (RhythmSign Fermata Simple NoDot Nothing))
-  , Test $ mkParseTest "B\n" (Rest 1 1 (RhythmSign Breve Simple NoDot Nothing))
-  , Test $ mkParseTest "W\n" (Rest 1 1 (RhythmSign Semibreve Simple NoDot Nothing))
-  , Test $ mkParseTest "W.\n" (Rest 1 1 (RhythmSign Semibreve Simple Dot Nothing))
-  , Test $ mkParseTest "W3\n" (Rest 1 1 (RhythmSign Semibreve Compound NoDot Nothing))
-  , Test $ mkParseTest "H\n" (Rest 1 1 (RhythmSign Minim Simple NoDot Nothing))
-  , Test $ mkParseTest "H.\n" (Rest 1 1 (RhythmSign Minim Simple Dot Nothing))
-  , Test $ mkParseTest "H3\n" (Rest 1 1 (RhythmSign Minim Compound NoDot Nothing))
-  , Test $ mkParseTest "Q\n" (Rest 1 1 (RhythmSign Crotchet Simple NoDot Nothing))
-  , Test $ mkParseTest "Q.\n" (Rest 1 1 (RhythmSign Crotchet Simple Dot Nothing))
-  , Test $ mkParseTest "Q3\n" (Rest 1 1 (RhythmSign Crotchet Compound NoDot Nothing))
-  , Test $ mkParseTest "E\n" (Rest 1 1 (RhythmSign Quaver Simple NoDot Nothing))
-  , Test $ mkParseTest "E.\n" (Rest 1 1 (RhythmSign Quaver Simple Dot Nothing))
-  , Test $ mkParseTest "E3\n" (Rest 1 1 (RhythmSign Quaver Compound NoDot Nothing))
-  , Test $ mkParseTest "S\n" (Rest 1 1 (RhythmSign Semiquaver Simple NoDot Nothing))
-  , Test $ mkParseTest "S.\n" (Rest 1 1 (RhythmSign Semiquaver Simple Dot Nothing))
-  , Test $ mkParseTest "S3\n" (Rest 1 1 (RhythmSign Semiquaver Compound NoDot Nothing))
-  , Test $ mkParseTest "T\n" (Rest 1 1 (RhythmSign Demisemiquaver Simple NoDot Nothing))
-  , Test $ mkParseTest "T.\n" (Rest 1 1 (RhythmSign Demisemiquaver Simple Dot Nothing))
-  , Test $ mkParseTest "T3\n" (Rest 1 1 (RhythmSign Demisemiquaver Compound NoDot Nothing))
-  , Test $ mkParseTest "Y\n" (Rest 1 1 (RhythmSign Hemidemisemiquaver Simple NoDot Nothing))
-  , Test $ mkParseTest "Y.\n" (Rest 1 1 (RhythmSign Hemidemisemiquaver Simple Dot Nothing))
-  , Test $ mkParseTest "Y3\n" (Rest 1 1 (RhythmSign Hemidemisemiquaver Compound NoDot Nothing))
-  , Test $ mkParseTest "Z\n" (Rest 1 1 (RhythmSign Semihemidemisemiquaver Simple NoDot Nothing))
-  , Test $ mkParseTest "Z.\n" (Rest 1 1 (RhythmSign Semihemidemisemiquaver Simple Dot Nothing))
-  , Test $ mkParseTest "Z3\n" (Rest 1 1 (RhythmSign Semihemidemisemiquaver Compound NoDot Nothing))
+  [ Test $ mkParseTest "F\n" (Rest 1 1 (RhythmSign Fermata Simple NoDot Nothing) Nothing)
+  , Test $ mkParseTest "B\n" (Rest 1 1 (RhythmSign Breve Simple NoDot Nothing) Nothing)
+  , Test $ mkParseTest "W\n" (Rest 1 1 (RhythmSign Semibreve Simple NoDot Nothing) Nothing)
+  , Test $ mkParseTest "W.\n" (Rest 1 1 (RhythmSign Semibreve Simple Dot Nothing) Nothing)
+  , Test $ mkParseTest "W3\n" (Rest 1 1 (RhythmSign Semibreve Compound NoDot Nothing) Nothing)
+  , Test $ mkParseTest "H\n" (Rest 1 1 (RhythmSign Minim Simple NoDot Nothing) Nothing)
+  , Test $ mkParseTest "H.\n" (Rest 1 1 (RhythmSign Minim Simple Dot Nothing) Nothing)
+  , Test $ mkParseTest "H3\n" (Rest 1 1 (RhythmSign Minim Compound NoDot Nothing) Nothing)
+  , Test $ mkParseTest "Q\n" (Rest 1 1 (RhythmSign Crotchet Simple NoDot Nothing) Nothing)
+  , Test $ mkParseTest "Q.\n" (Rest 1 1 (RhythmSign Crotchet Simple Dot Nothing) Nothing)
+  , Test $ mkParseTest "Q3\n" (Rest 1 1 (RhythmSign Crotchet Compound NoDot Nothing) Nothing)
+  , Test $ mkParseTest "E\n" (Rest 1 1 (RhythmSign Quaver Simple NoDot Nothing) Nothing)
+  , Test $ mkParseTest "E.\n" (Rest 1 1 (RhythmSign Quaver Simple Dot Nothing) Nothing)
+  , Test $ mkParseTest "E3\n" (Rest 1 1 (RhythmSign Quaver Compound NoDot Nothing) Nothing)
+  , Test $ mkParseTest "S\n" (Rest 1 1 (RhythmSign Semiquaver Simple NoDot Nothing) Nothing)
+  , Test $ mkParseTest "S.\n" (Rest 1 1 (RhythmSign Semiquaver Simple Dot Nothing) Nothing)
+  , Test $ mkParseTest "S3\n" (Rest 1 1 (RhythmSign Semiquaver Compound NoDot Nothing) Nothing)
+  , Test $ mkParseTest "T\n" (Rest 1 1 (RhythmSign Demisemiquaver Simple NoDot Nothing) Nothing)
+  , Test $ mkParseTest "T.\n" (Rest 1 1 (RhythmSign Demisemiquaver Simple Dot Nothing) Nothing)
+  , Test $ mkParseTest "T3\n" (Rest 1 1 (RhythmSign Demisemiquaver Compound NoDot Nothing) Nothing)
+  , Test $ mkParseTest "Y\n" (Rest 1 1 (RhythmSign Hemidemisemiquaver Simple NoDot Nothing) Nothing)
+  , Test $ mkParseTest "Y.\n" (Rest 1 1 (RhythmSign Hemidemisemiquaver Simple Dot Nothing) Nothing)
+  , Test $ mkParseTest "Y3\n" (Rest 1 1 (RhythmSign Hemidemisemiquaver Compound NoDot Nothing) Nothing)
+  , Test $ mkParseTest "Z\n" (Rest 1 1 (RhythmSign Semihemidemisemiquaver Simple NoDot Nothing) Nothing)
+  , Test $ mkParseTest "Z.\n" (Rest 1 1 (RhythmSign Semihemidemisemiquaver Simple Dot Nothing) Nothing)
+  , Test $ mkParseTest "Z3\n" (Rest 1 1 (RhythmSign Semihemidemisemiquaver Compound NoDot Nothing) Nothing)
   ]
 
 barLines :: [Test]
 barLines =
-  [ Test $ mkParseTest "|\n" (BarLine 1 1 (SingleBar Nothing Nothing NotDashed Counting))
-  , Test $ mkParseTest "||\n" (BarLine 1 1 (DoubleBar Nothing Nothing NotDashed Counting))
-  , Test $ mkParseTest ":|\n" (BarLine 1 1 (SingleBar (Just RepeatLeft) Nothing NotDashed Counting))
-  , Test $ mkParseTest ":||\n" (BarLine 1 1 (DoubleBar (Just RepeatLeft) Nothing NotDashed Counting))
-  , Test $ mkParseTest "|:\n" (BarLine 1 1 (SingleBar (Just RepeatRight) Nothing NotDashed Counting))
-  , Test $ mkParseTest "||:\n" (BarLine 1 1 (DoubleBar (Just RepeatRight) Nothing NotDashed Counting))
-  , Test $ mkParseTest ":|:\n" (BarLine 1 1 (SingleBar (Just RepeatBoth) Nothing NotDashed Counting))
-  , Test $ mkParseTest ":||:\n" (BarLine 1 1 (DoubleBar (Just RepeatBoth) Nothing NotDashed Counting))
-  , Test $ mkParseTest "|=\n" (BarLine 1 1 (SingleBar Nothing Nothing Dashed Counting))
-  , Test $ mkParseTest "||=\n" (BarLine 1 1 (DoubleBar Nothing Nothing Dashed Counting))
-  , Test $ mkParseTest ":|=\n" (BarLine 1 1 (SingleBar (Just RepeatLeft) Nothing Dashed Counting))
-  , Test $ mkParseTest ":||=\n" (BarLine 1 1 (DoubleBar (Just RepeatLeft) Nothing Dashed Counting))
-  , Test $ mkParseTest "|:=\n" (BarLine 1 1 (SingleBar (Just RepeatRight) Nothing Dashed Counting))
-  , Test $ mkParseTest "||:=\n" (BarLine 1 1 (DoubleBar (Just RepeatRight) Nothing Dashed Counting))
-  , Test $ mkParseTest ":|:=\n" (BarLine 1 1 (SingleBar (Just RepeatBoth) Nothing Dashed Counting))
-  , Test $ mkParseTest ":||:=\n" (BarLine 1 1 (DoubleBar (Just RepeatBoth) Nothing Dashed Counting))
-  , Test $ mkParseTest "|0\n" (BarLine 1 1 (SingleBar Nothing Nothing NotDashed NotCounting))
-  , Test $ mkParseTest "||0\n" (BarLine 1 1 (DoubleBar Nothing Nothing NotDashed NotCounting))
-  , Test $ mkParseTest ":|0\n" (BarLine 1 1 (SingleBar (Just RepeatLeft) Nothing NotDashed NotCounting))
-  , Test $ mkParseTest ":||0\n" (BarLine 1 1 (DoubleBar (Just RepeatLeft) Nothing NotDashed NotCounting))
-  , Test $ mkParseTest "|:0\n" (BarLine 1 1 (SingleBar (Just RepeatRight) Nothing NotDashed NotCounting))
-  , Test $ mkParseTest "||:0\n" (BarLine 1 1 (DoubleBar (Just RepeatRight) Nothing NotDashed NotCounting))
-  , Test $ mkParseTest ":|:0\n" (BarLine 1 1 (SingleBar (Just RepeatBoth) Nothing NotDashed NotCounting))
-  , Test $ mkParseTest ":||:0\n" (BarLine 1 1 (DoubleBar (Just RepeatBoth) Nothing NotDashed NotCounting))
-  , Test $ mkParseTest "|(T=:\\R)\n" (BarLine 1 1 (SingleBar Nothing (Just Reprise) NotDashed Counting))
-  , Test $ mkParseTest "||(T=:\\R)\n" (BarLine 1 1 (DoubleBar Nothing (Just Reprise) NotDashed Counting))
-  , Test $ mkParseTest "|(T+:\\1)\n" (BarLine 1 1 (SingleBar Nothing (Just $ NthTime 1) NotDashed Counting))
-  , Test $ mkParseTest "||(T+:\\1)\n" (BarLine 1 1 (DoubleBar Nothing (Just $ NthTime 1) NotDashed Counting))
+  [ Test $ mkParseTest "|\n" (BarLine 1 1 (SingleBar Nothing Nothing NotDashed Counting) Nothing)
+  , Test $ mkParseTest "||\n" (BarLine 1 1 (DoubleBar Nothing Nothing NotDashed Counting) Nothing)
+  , Test $ mkParseTest ":|\n" (BarLine 1 1 (SingleBar (Just RepeatLeft) Nothing NotDashed Counting) Nothing)
+  , Test $ mkParseTest ":||\n" (BarLine 1 1 (DoubleBar (Just RepeatLeft) Nothing NotDashed Counting) Nothing)
+  , Test $ mkParseTest "|:\n" (BarLine 1 1 (SingleBar (Just RepeatRight) Nothing NotDashed Counting) Nothing)
+  , Test $ mkParseTest "||:\n" (BarLine 1 1 (DoubleBar (Just RepeatRight) Nothing NotDashed Counting) Nothing)
+  , Test $ mkParseTest ":|:\n" (BarLine 1 1 (SingleBar (Just RepeatBoth) Nothing NotDashed Counting) Nothing)
+  , Test $ mkParseTest ":||:\n" (BarLine 1 1 (DoubleBar (Just RepeatBoth) Nothing NotDashed Counting) Nothing)
+  , Test $ mkParseTest "|=\n" (BarLine 1 1 (SingleBar Nothing Nothing Dashed Counting) Nothing)
+  , Test $ mkParseTest "||=\n" (BarLine 1 1 (DoubleBar Nothing Nothing Dashed Counting) Nothing)
+  , Test $ mkParseTest ":|=\n" (BarLine 1 1 (SingleBar (Just RepeatLeft) Nothing Dashed Counting) Nothing)
+  , Test $ mkParseTest ":||=\n" (BarLine 1 1 (DoubleBar (Just RepeatLeft) Nothing Dashed Counting) Nothing)
+  , Test $ mkParseTest "|:=\n" (BarLine 1 1 (SingleBar (Just RepeatRight) Nothing Dashed Counting) Nothing)
+  , Test $ mkParseTest "||:=\n" (BarLine 1 1 (DoubleBar (Just RepeatRight) Nothing Dashed Counting) Nothing)
+  , Test $ mkParseTest ":|:=\n" (BarLine 1 1 (SingleBar (Just RepeatBoth) Nothing Dashed Counting) Nothing)
+  , Test $ mkParseTest ":||:=\n" (BarLine 1 1 (DoubleBar (Just RepeatBoth) Nothing Dashed Counting) Nothing)
+  , Test $ mkParseTest "|0\n" (BarLine 1 1 (SingleBar Nothing Nothing NotDashed NotCounting) Nothing)
+  , Test $ mkParseTest "||0\n" (BarLine 1 1 (DoubleBar Nothing Nothing NotDashed NotCounting) Nothing)
+  , Test $ mkParseTest ":|0\n" (BarLine 1 1 (SingleBar (Just RepeatLeft) Nothing NotDashed NotCounting) Nothing)
+  , Test $ mkParseTest ":||0\n" (BarLine 1 1 (DoubleBar (Just RepeatLeft) Nothing NotDashed NotCounting) Nothing)
+  , Test $ mkParseTest "|:0\n" (BarLine 1 1 (SingleBar (Just RepeatRight) Nothing NotDashed NotCounting) Nothing)
+  , Test $ mkParseTest "||:0\n" (BarLine 1 1 (DoubleBar (Just RepeatRight) Nothing NotDashed NotCounting) Nothing)
+  , Test $ mkParseTest ":|:0\n" (BarLine 1 1 (SingleBar (Just RepeatBoth) Nothing NotDashed NotCounting) Nothing)
+  , Test $ mkParseTest ":||:0\n" (BarLine 1 1 (DoubleBar (Just RepeatBoth) Nothing NotDashed NotCounting) Nothing)
+  , Test $ mkParseTest "|(T=:\\R)\n" (BarLine 1 1 (SingleBar Nothing (Just Reprise) NotDashed Counting) Nothing)
+  , Test $ mkParseTest "||(T=:\\R)\n" (BarLine 1 1 (DoubleBar Nothing (Just Reprise) NotDashed Counting) Nothing)
+  , Test $ mkParseTest "|(T+:\\1)\n" (BarLine 1 1 (SingleBar Nothing (Just $ NthTime 1) NotDashed Counting) Nothing)
+  , Test $ mkParseTest "||(T+:\\1)\n" (BarLine 1 1 (DoubleBar Nothing (Just $ NthTime 1) NotDashed Counting) Nothing)
   ]
 
 simpleChords :: [Test]
 simpleChords =
-  [ Test $ mkParseTest "c1\n" (Chord 1 1 Nothing [Note One C (Nothing, Nothing) Nothing Nothing Nothing])
+  [ Test $ mkParseTest "c1\n" (Chord 1 1 Nothing [Note One C (Nothing, Nothing) Nothing Nothing Nothing] Nothing)
   , Test $ mkParseTest "c1a2\n" (Chord 1 1 Nothing [ Note One C (Nothing, Nothing) Nothing Nothing Nothing
-                                                   , Note Two A (Nothing, Nothing) Nothing Nothing Nothing ])
-  , Test $ mkParseTest "Qc1\n" (Chord 1 1 (Just (RhythmSign Crotchet Simple NoDot Nothing)) [Note One C (Nothing, Nothing) Nothing Nothing Nothing])
-  , Test $ mkParseTest "Q.c1\n" (Chord 1 1 (Just (RhythmSign Crotchet Simple Dot Nothing)) [Note One C (Nothing, Nothing) Nothing Nothing Nothing])
-  , Test $ mkParseTest "Q3c1\n" (Chord 1 1 (Just (RhythmSign Crotchet Compound NoDot Nothing)) [Note One C (Nothing, Nothing) Nothing Nothing Nothing])
+                                                   , Note Two A (Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
+  , Test $ mkParseTest "Qc1\n" (Chord 1 1 (Just (RhythmSign Crotchet Simple NoDot Nothing)) [Note One C (Nothing, Nothing) Nothing Nothing Nothing] Nothing)
+  , Test $ mkParseTest "Q.c1\n" (Chord 1 1 (Just (RhythmSign Crotchet Simple Dot Nothing)) [Note One C (Nothing, Nothing) Nothing Nothing Nothing] Nothing)
+  , Test $ mkParseTest "Q3c1\n" (Chord 1 1 (Just (RhythmSign Crotchet Compound NoDot Nothing)) [Note One C (Nothing, Nothing) Nothing Nothing Nothing] Nothing)
   , Test $ mkParseTest "Qc1a2\n" (Chord 1 1 (Just (RhythmSign Crotchet Simple NoDot Nothing)) [ Note One C (Nothing, Nothing) Nothing Nothing Nothing
-                                                                                              , Note Two A (Nothing, Nothing) Nothing Nothing Nothing ])
+                                                                                              , Note Two A (Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
   ]
 
 chordsWithBass :: [Test]
 chordsWithBass =
-  [ Test $ mkParseTest "Xa\n" (Chord 1 1 Nothing [Note (Bass 1) A (Nothing, Nothing) Nothing Nothing Nothing])
-  , Test $ mkParseTest "Xa/\n" (Chord 1 1 Nothing [Note (Bass 2) A (Nothing, Nothing) Nothing Nothing Nothing])
-  , Test $ mkParseTest "Xb//\n" (Chord 1 1 Nothing [Note (Bass 3) B (Nothing, Nothing) Nothing Nothing Nothing])
-  , Test $ mkParseTest "X1\n" (Chord 1 1 Nothing [Note (Bass 1) A (Nothing, Nothing) Nothing Nothing Nothing])
-  , Test $ mkParseTest "X4\n" (Chord 1 1 Nothing [Note (Bass 4) A (Nothing, Nothing) Nothing Nothing Nothing])
+  [ Test $ mkParseTest "Xa\n" (Chord 1 1 Nothing [Note (Bass 1) A (Nothing, Nothing) Nothing Nothing Nothing] Nothing)
+  , Test $ mkParseTest "Xa/\n" (Chord 1 1 Nothing [Note (Bass 2) A (Nothing, Nothing) Nothing Nothing Nothing] Nothing)
+  , Test $ mkParseTest "Xb//\n" (Chord 1 1 Nothing [Note (Bass 3) B (Nothing, Nothing) Nothing Nothing Nothing] Nothing)
+  , Test $ mkParseTest "X1\n" (Chord 1 1 Nothing [Note (Bass 1) A (Nothing, Nothing) Nothing Nothing Nothing] Nothing)
+  , Test $ mkParseTest "X4\n" (Chord 1 1 Nothing [Note (Bass 4) A (Nothing, Nothing) Nothing Nothing Nothing] Nothing)
   , Test $ mkParseTest "c1Xa\n" (Chord 1 1 Nothing [ Note One C (Nothing, Nothing) Nothing Nothing Nothing
-                                                   , Note (Bass 1) A (Nothing, Nothing) Nothing Nothing Nothing ])
+                                                   , Note (Bass 1) A (Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
   , Test $ mkParseTest "c1Xa/\n" (Chord 1 1 Nothing [ Note One C (Nothing, Nothing) Nothing Nothing Nothing
-                                                    , Note (Bass 2) A (Nothing, Nothing) Nothing Nothing Nothing ])
+                                                    , Note (Bass 2) A (Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
   , Test $ mkParseTest "c1Xb//\n" (Chord 1 1 Nothing [ Note One C (Nothing, Nothing) Nothing Nothing Nothing
-                                                     , Note (Bass 3) B (Nothing, Nothing) Nothing Nothing Nothing ])
+                                                     , Note (Bass 3) B (Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
   , Test $ mkParseTest "c1X1\n" (Chord 1 1 Nothing [ Note One C (Nothing, Nothing) Nothing Nothing Nothing
-                                                   , Note (Bass 1) A (Nothing, Nothing) Nothing Nothing Nothing ])
+                                                   , Note (Bass 1) A (Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
   , Test $ mkParseTest "c1X4\n" (Chord 1 1 Nothing [ Note One C (Nothing, Nothing) Nothing Nothing Nothing
-                                                   , Note (Bass 4) A (Nothing, Nothing) Nothing Nothing Nothing ])
+                                                   , Note (Bass 4) A (Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
   , Test $ mkParseTest "Q.Xa\n" (Chord 1 1 (Just (RhythmSign Crotchet Simple Dot Nothing))
-                                  [Note (Bass 1) A (Nothing, Nothing) Nothing Nothing Nothing])
+                                  [Note (Bass 1) A (Nothing, Nothing) Nothing Nothing Nothing] Nothing)
   , Test $ mkParseTest "Q.Xa/\n" (Chord 1 1 (Just (RhythmSign Crotchet Simple Dot Nothing))
-                                   [Note (Bass 2) A (Nothing, Nothing) Nothing Nothing Nothing])
+                                   [Note (Bass 2) A (Nothing, Nothing) Nothing Nothing Nothing] Nothing)
   , Test $ mkParseTest "Q.Xb//\n" (Chord 1 1 (Just (RhythmSign Crotchet Simple Dot Nothing))
-                                   [Note (Bass 3) B (Nothing, Nothing) Nothing Nothing Nothing])
+                                   [Note (Bass 3) B (Nothing, Nothing) Nothing Nothing Nothing] Nothing)
   , Test $ mkParseTest "Q.X1\n" (Chord 1 1 (Just (RhythmSign Crotchet Simple Dot Nothing))
-                                  [Note (Bass 1) A (Nothing, Nothing) Nothing Nothing Nothing])
+                                  [Note (Bass 1) A (Nothing, Nothing) Nothing Nothing Nothing] Nothing)
   , Test $ mkParseTest "Q.X4\n" (Chord 1 1 (Just (RhythmSign Crotchet Simple Dot Nothing))
-                                  [Note (Bass 4) A (Nothing, Nothing) Nothing Nothing Nothing])
+                                  [Note (Bass 4) A (Nothing, Nothing) Nothing Nothing Nothing] Nothing)
   , Test $ mkParseTest "Q.c1Xa\n" (Chord 1 1 (Just (RhythmSign Crotchet Simple Dot Nothing))
                                     [ Note One C (Nothing, Nothing) Nothing Nothing Nothing
-                                    , Note (Bass 1) A (Nothing, Nothing) Nothing Nothing Nothing ])
+                                    , Note (Bass 1) A (Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
   , Test $ mkParseTest "Q.c1Xa/\n" (Chord 1 1 (Just (RhythmSign Crotchet Simple Dot Nothing))
                                      [ Note One C (Nothing, Nothing) Nothing Nothing Nothing
-                                     , Note (Bass 2) A (Nothing, Nothing) Nothing Nothing Nothing ])
+                                     , Note (Bass 2) A (Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
   , Test $ mkParseTest "Q.c1Xb//\n" (Chord 1 1 (Just (RhythmSign Crotchet Simple Dot Nothing))
                                       [ Note One C (Nothing, Nothing) Nothing Nothing Nothing
-                                      , Note (Bass 3) B (Nothing, Nothing) Nothing Nothing Nothing ])
+                                      , Note (Bass 3) B (Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
   , Test $ mkParseTest "Q.c1X1\n" (Chord 1 1 (Just (RhythmSign Crotchet Simple Dot Nothing))
                                     [ Note One C (Nothing, Nothing) Nothing Nothing Nothing
-                                    , Note (Bass 1) A (Nothing, Nothing) Nothing Nothing Nothing ])
+                                    , Note (Bass 1) A (Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
   , Test $ mkParseTest "Q.c1X4\n" (Chord 1 1 (Just (RhythmSign Crotchet Simple Dot Nothing))
                                     [ Note One C (Nothing, Nothing) Nothing Nothing Nothing
-                                    , Note (Bass 4) A (Nothing, Nothing) Nothing Nothing Nothing ])
+                                    , Note (Bass 4) A (Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
   ]
 
 failChords :: [Test]
@@ -241,36 +242,36 @@ failChords =
 articulations :: [Test]
 articulations =
   [ Test $ mkParseTest "b3(E)d4\n" (Chord 1 1 Nothing [ Note Three B (Nothing, Nothing) Nothing (Just Ensemble) Nothing
-                                                      , Note Four D (Nothing, Nothing) Nothing Nothing Nothing ])
+                                                      , Note Four D (Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
   , Test $ mkParseTest "Hc1c2d3(E)d6\n" (Chord 1 1 (Just (RhythmSign Minim Simple NoDot Nothing))
                                           [ Note One C (Nothing, Nothing) Nothing Nothing Nothing
                                           , Note Two C (Nothing, Nothing) Nothing Nothing Nothing
                                           , Note Three D (Nothing, Nothing) Nothing (Just Ensemble) Nothing
-                                          , Note Six D (Nothing, Nothing) Nothing Nothing Nothing ])
+                                          , Note Six D (Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
   , Test $ mkParseTest "c1(E)X4" (Chord 1 1 Nothing [ Note One C (Nothing, Nothing) Nothing (Just Ensemble) Nothing
-                                                    , Note (Bass 4) A (Nothing, Nothing) Nothing Nothing Nothing ])
+                                                    , Note (Bass 4) A (Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
   , Test $ mkParseTest "b3(S)d4\n" (Chord 1 1 Nothing [ Note Three B (Nothing, Nothing) Nothing (Just $ Separee Nothing Nothing) Nothing
-                                                      , Note Four D (Nothing, Nothing) Nothing Nothing Nothing ])
+                                                      , Note Four D (Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
   , Test $ mkParseTest "Hc1c2d3(S)d6\n" (Chord 1 1 (Just (RhythmSign Minim Simple NoDot Nothing))
                                           [ Note One C (Nothing, Nothing) Nothing Nothing Nothing
                                           , Note Two C (Nothing, Nothing) Nothing Nothing Nothing
                                           , Note Three D (Nothing, Nothing) Nothing (Just $ Separee Nothing Nothing) Nothing
-                                          , Note Six D (Nothing, Nothing) Nothing Nothing Nothing ])
+                                          , Note Six D (Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
   , Test $ mkParseTest "c1(S)X4" (Chord 1 1 Nothing [ Note One C (Nothing, Nothing) Nothing (Just $ Separee Nothing Nothing) Nothing
-                                                    , Note (Bass 4) A (Nothing, Nothing) Nothing Nothing Nothing ])
+                                                    , Note (Bass 4) A (Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
   , Test $ mkParseTest "b3(Sd)d4\n" (Chord 1 1 Nothing [ Note Three B (Nothing, Nothing) Nothing (Just $ Separee (Just SepareeDown) Nothing) Nothing
-                                                       , Note Four D (Nothing, Nothing) Nothing Nothing Nothing ])
+                                                       , Note Four D (Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
   , Test $ mkParseTest "b3(Su)d4\n" (Chord 1 1 Nothing [ Note Three B (Nothing, Nothing) Nothing (Just $ Separee (Just SepareeUp) Nothing) Nothing
-                                                       , Note Four D (Nothing, Nothing) Nothing Nothing Nothing ])
+                                                       , Note Four D (Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
   , Test $ mkParseTest "b3(Sd:l)d4\n" (Chord 1 1 Nothing [ Note Three B (Nothing, Nothing) Nothing (Just $ Separee (Just SepareeDown) (Just SepareeLeft)) Nothing
-                                                         , Note Four D (Nothing, Nothing) Nothing Nothing Nothing ])
+                                                         , Note Four D (Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
   , Test $ mkParseTest "b3(Su:r)d4\n" (Chord 1 1 Nothing [ Note Three B (Nothing, Nothing) Nothing (Just $ Separee (Just SepareeUp) (Just SepareeRight)) Nothing
-                                                         , Note Four D (Nothing, Nothing) Nothing Nothing Nothing ])
+                                                         , Note Four D (Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
   , Test $ mkParseTest "Hc1(E)c2d3(S)d6\n" (Chord 1 1 (Just (RhythmSign Minim Simple NoDot Nothing))
                                             [ Note One C (Nothing, Nothing) Nothing (Just Ensemble) Nothing
                                             , Note Two C (Nothing, Nothing) Nothing Nothing Nothing
                                             , Note Three D (Nothing, Nothing) Nothing (Just $ Separee Nothing Nothing) Nothing
-                                            , Note Six D (Nothing, Nothing) Nothing Nothing Nothing ])
+                                            , Note Six D (Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
   , Test $ mkInvalidTest "b3(E)(S)d4\n"
   , Test $ mkInvalidTest "b3(S)(E)d4\n"
   , Test $ mkInvalidTest "b3(E)(Su)d4\n"
@@ -279,23 +280,23 @@ articulations =
 
 fingerings :: [Test]
 fingerings =
-  [ Test $ mkParseTest "c1(Fr...:7)\n" (Chord 1 1 Nothing [ Note One C (Just $ FingeringRight FingerThree (Just PosBelow), Nothing) Nothing Nothing Nothing ])
-  , Test $ mkParseTest "c1(F...)\n" (Chord 1 1 Nothing [ Note One C (Just $ FingeringRight FingerThree Nothing, Nothing) Nothing Nothing Nothing ])
-  , Test $ mkParseTest "c1(F...:6)\n" (Chord 1 1 Nothing [ Note One C (Just $ FingeringRight FingerThree (Just PosBelowLeft), Nothing) Nothing Nothing Nothing ])
-  , Test $ mkParseTest "c1(F2:6)\n" (Chord 1 1 Nothing [ Note One C (Just $ FingeringLeft FingerTwo (Just PosBelowLeft), Nothing) Nothing Nothing Nothing ])
-  , Test $ mkParseTest "c1(F2)\n" (Chord 1 1 Nothing [ Note One C (Just $ FingeringLeft FingerTwo Nothing, Nothing) Nothing Nothing Nothing ])
-  , Test $ mkParseTest "c1(Fl2:6)\n" (Chord 1 1 Nothing [ Note One C (Just $ FingeringLeft FingerTwo (Just PosBelowLeft), Nothing) Nothing Nothing Nothing ])
-  , Test $ mkParseTest "c1(Fr2:6)\n" (Chord 1 1 Nothing [ Note One C (Just $ FingeringRight FingerTwo (Just PosBelowLeft), Nothing) Nothing Nothing Nothing ])
-  , Test $ mkParseTest "c1(Fr2)\n" (Chord 1 1 Nothing [ Note One C (Just $ FingeringRight FingerTwo Nothing, Nothing) Nothing Nothing Nothing ])
-  , Test $ mkParseTest "c1.\n" (Chord 1 1 Nothing [ Note One C (Just $ FingeringRight FingerOne Nothing, Nothing) Nothing Nothing Nothing ])
-  , Test $ mkParseTest "c1:\n" (Chord 1 1 Nothing [ Note One C (Just $ FingeringRight FingerTwo Nothing, Nothing) Nothing Nothing Nothing ])
-  , Test $ mkParseTest "c1!\n" (Chord 1 1 Nothing [ Note One C (Just $ FingeringRight Thumb Nothing, Nothing) Nothing Nothing Nothing ])
-  , Test $ mkParseTest "c1\"\n" (Chord 1 1 Nothing [ Note One C (Just $ FingeringRight FingerTwo Nothing, Nothing) Nothing Nothing Nothing ])
-  , Test $ mkParseTest "c1(Fl2)!\n" (Chord 1 1 Nothing [ Note One C (Just $ FingeringLeft FingerTwo Nothing, Just $ FingeringRight Thumb Nothing) Nothing Nothing Nothing ])
-  , Test $ mkParseTest "c1(Fl2)\"\n" (Chord 1 1 Nothing [ Note One C (Just $ FingeringLeft FingerTwo Nothing, Just $ FingeringRight FingerTwo Nothing) Nothing Nothing Nothing ])
-  , Test $ mkParseTest "c1!(Fl2)\n" (Chord 1 1 Nothing [ Note One C (Just $ FingeringRight Thumb Nothing, Just $ FingeringLeft FingerTwo Nothing) Nothing Nothing Nothing ])
-  , Test $ mkParseTest "c1\"(Fl2)\n" (Chord 1 1 Nothing [ Note One C (Just $ FingeringRight FingerTwo Nothing, Just $ FingeringLeft FingerTwo Nothing) Nothing Nothing Nothing ])
-  , Test $ mkParseTest "c1(Fr!)(Fl2)\n" (Chord 1 1 Nothing [ Note One C (Just $ FingeringRight Thumb Nothing, Just $ FingeringLeft FingerTwo Nothing) Nothing Nothing Nothing ])
+  [ Test $ mkParseTest "c1(Fr...:7)\n" (Chord 1 1 Nothing [ Note One C (Just $ FingeringRight FingerThree (Just PosBelow), Nothing) Nothing Nothing Nothing ] Nothing)
+  , Test $ mkParseTest "c1(F...)\n" (Chord 1 1 Nothing [ Note One C (Just $ FingeringRight FingerThree Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
+  , Test $ mkParseTest "c1(F...:6)\n" (Chord 1 1 Nothing [ Note One C (Just $ FingeringRight FingerThree (Just PosBelowLeft), Nothing) Nothing Nothing Nothing ] Nothing)
+  , Test $ mkParseTest "c1(F2:6)\n" (Chord 1 1 Nothing [ Note One C (Just $ FingeringLeft FingerTwo (Just PosBelowLeft), Nothing) Nothing Nothing Nothing ] Nothing)
+  , Test $ mkParseTest "c1(F2)\n" (Chord 1 1 Nothing [ Note One C (Just $ FingeringLeft FingerTwo Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
+  , Test $ mkParseTest "c1(Fl2:6)\n" (Chord 1 1 Nothing [ Note One C (Just $ FingeringLeft FingerTwo (Just PosBelowLeft), Nothing) Nothing Nothing Nothing ] Nothing)
+  , Test $ mkParseTest "c1(Fr2:6)\n" (Chord 1 1 Nothing [ Note One C (Just $ FingeringRight FingerTwo (Just PosBelowLeft), Nothing) Nothing Nothing Nothing ] Nothing)
+  , Test $ mkParseTest "c1(Fr2)\n" (Chord 1 1 Nothing [ Note One C (Just $ FingeringRight FingerTwo Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
+  , Test $ mkParseTest "c1.\n" (Chord 1 1 Nothing [ Note One C (Just $ FingeringRight FingerOne Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
+  , Test $ mkParseTest "c1:\n" (Chord 1 1 Nothing [ Note One C (Just $ FingeringRight FingerTwo Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
+  , Test $ mkParseTest "c1!\n" (Chord 1 1 Nothing [ Note One C (Just $ FingeringRight Thumb Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
+  , Test $ mkParseTest "c1\"\n" (Chord 1 1 Nothing [ Note One C (Just $ FingeringRight FingerTwo Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
+  , Test $ mkParseTest "c1(Fl2)!\n" (Chord 1 1 Nothing [ Note One C (Just $ FingeringLeft FingerTwo Nothing, Just $ FingeringRight Thumb Nothing) Nothing Nothing Nothing ] Nothing)
+  , Test $ mkParseTest "c1(Fl2)\"\n" (Chord 1 1 Nothing [ Note One C (Just $ FingeringLeft FingerTwo Nothing, Just $ FingeringRight FingerTwo Nothing) Nothing Nothing Nothing ] Nothing)
+  , Test $ mkParseTest "c1!(Fl2)\n" (Chord 1 1 Nothing [ Note One C (Just $ FingeringRight Thumb Nothing, Just $ FingeringLeft FingerTwo Nothing) Nothing Nothing Nothing ] Nothing)
+  , Test $ mkParseTest "c1\"(Fl2)\n" (Chord 1 1 Nothing [ Note One C (Just $ FingeringRight FingerTwo Nothing, Just $ FingeringLeft FingerTwo Nothing) Nothing Nothing Nothing ] Nothing)
+  , Test $ mkParseTest "c1(Fr!)(Fl2)\n" (Chord 1 1 Nothing [ Note One C (Just $ FingeringRight Thumb Nothing, Just $ FingeringLeft FingerTwo Nothing) Nothing Nothing Nothing ] Nothing)
   , Test $ mkInvalidTest "c1(Fl..:7)\n"
   , Test $ mkInvalidTest "c1(Fr...:9)\n"
   , Test $ mkInvalidTest "c1(F.....)\n"
@@ -307,33 +308,33 @@ fingerings =
 
 ornaments :: [Test]
 ornaments =
-  [ Test $ mkParseTest "b2(Oa)\n" (Chord 1 1 Nothing [ Note Two B (Nothing, Nothing) (Just $ OrnA Nothing Nothing) Nothing Nothing ])
-  , Test $ mkParseTest "b2(Oa1)\n" (Chord 1 1 Nothing [ Note Two B (Nothing, Nothing) (Just $ OrnA (Just 1) Nothing) Nothing Nothing ])
-  , Test $ mkParseTest "b2(Oa:1)\n" (Chord 1 1 Nothing [ Note Two B (Nothing, Nothing) (Just $ OrnA Nothing (Just PosAboveLeft)) Nothing Nothing ])
-  , Test $ mkParseTest "b2(Oa2:5)\n" (Chord 1 1 Nothing [ Note Two B (Nothing, Nothing) (Just $ OrnA (Just 2) (Just PosRight)) Nothing Nothing ])
-  , Test $ mkParseTest "b2,\n" (Chord 1 1 Nothing [ Note Two B (Nothing, Nothing) (Just $ OrnA (Just 1) Nothing) Nothing Nothing ])
-  , Test $ mkParseTest "b2(C)\n" (Chord 1 1 Nothing [ Note Two B (Nothing, Nothing) (Just $ OrnB Nothing Nothing) Nothing Nothing ])
-  , Test $ mkParseTest "b2u\n" (Chord 1 1 Nothing [ Note Two B (Nothing, Nothing) (Just $ OrnC (Just 1) Nothing) Nothing Nothing ])
-  , Test $ mkParseTest "b2<\n" (Chord 1 1 Nothing [ Note Two B (Nothing, Nothing) (Just $ OrnC (Just 2) Nothing) Nothing Nothing ])
-  , Test $ mkParseTest "b2#\n" (Chord 1 1 Nothing [ Note Two B (Nothing, Nothing) (Just $ OrnE Nothing Nothing) Nothing Nothing ])
-  , Test $ mkParseTest "b2x\n" (Chord 1 1 Nothing [ Note Two B (Nothing, Nothing) (Just $ OrnF Nothing Nothing) Nothing Nothing ])
-  , Test $ mkParseTest "b2~\n" (Chord 1 1 Nothing [ Note Two B (Nothing, Nothing) (Just $ OrnH Nothing Nothing) Nothing Nothing ])
+  [ Test $ mkParseTest "b2(Oa)\n" (Chord 1 1 Nothing [ Note Two B (Nothing, Nothing) (Just $ OrnA Nothing Nothing) Nothing Nothing ] Nothing)
+  , Test $ mkParseTest "b2(Oa1)\n" (Chord 1 1 Nothing [ Note Two B (Nothing, Nothing) (Just $ OrnA (Just 1) Nothing) Nothing Nothing ] Nothing)
+  , Test $ mkParseTest "b2(Oa:1)\n" (Chord 1 1 Nothing [ Note Two B (Nothing, Nothing) (Just $ OrnA Nothing (Just PosAboveLeft)) Nothing Nothing ] Nothing)
+  , Test $ mkParseTest "b2(Oa2:5)\n" (Chord 1 1 Nothing [ Note Two B (Nothing, Nothing) (Just $ OrnA (Just 2) (Just PosRight)) Nothing Nothing ] Nothing)
+  , Test $ mkParseTest "b2,\n" (Chord 1 1 Nothing [ Note Two B (Nothing, Nothing) (Just $ OrnA (Just 1) Nothing) Nothing Nothing ] Nothing)
+  , Test $ mkParseTest "b2(C)\n" (Chord 1 1 Nothing [ Note Two B (Nothing, Nothing) (Just $ OrnB Nothing Nothing) Nothing Nothing ] Nothing)
+  , Test $ mkParseTest "b2u\n" (Chord 1 1 Nothing [ Note Two B (Nothing, Nothing) (Just $ OrnC (Just 1) Nothing) Nothing Nothing ] Nothing)
+  , Test $ mkParseTest "b2<\n" (Chord 1 1 Nothing [ Note Two B (Nothing, Nothing) (Just $ OrnC (Just 2) Nothing) Nothing Nothing ] Nothing)
+  , Test $ mkParseTest "b2#\n" (Chord 1 1 Nothing [ Note Two B (Nothing, Nothing) (Just $ OrnE Nothing Nothing) Nothing Nothing ] Nothing)
+  , Test $ mkParseTest "b2x\n" (Chord 1 1 Nothing [ Note Two B (Nothing, Nothing) (Just $ OrnF Nothing Nothing) Nothing Nothing ] Nothing)
+  , Test $ mkParseTest "b2~\n" (Chord 1 1 Nothing [ Note Two B (Nothing, Nothing) (Just $ OrnH Nothing Nothing) Nothing Nothing ] Nothing)
   , Test $ mkParseTest "b2(Oa)a3\n" (Chord 1 1 Nothing [ Note Two B (Nothing, Nothing) (Just $ OrnA Nothing Nothing) Nothing Nothing
-                                                       , Note Three A (Nothing, Nothing) Nothing Nothing Nothing ])
+                                                       , Note Three A (Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
   , Test $ mkParseTest "b2,a3\n" (Chord 1 1 Nothing [ Note Two B (Nothing, Nothing) (Just $ OrnA (Just 1) Nothing) Nothing Nothing
-                                                    , Note Three A (Nothing, Nothing) Nothing Nothing Nothing ])
+                                                    , Note Three A (Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
   , Test $ mkParseTest "b2(C)a3\n" (Chord 1 1 Nothing [ Note Two B (Nothing, Nothing) (Just $ OrnB Nothing Nothing) Nothing Nothing
-                                                      , Note Three A (Nothing, Nothing) Nothing Nothing Nothing ])
+                                                      , Note Three A (Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
   , Test $ mkParseTest "b2ua3\n" (Chord 1 1 Nothing [ Note Two B (Nothing, Nothing) (Just $ OrnC (Just 1) Nothing) Nothing Nothing
-                                                    , Note Three A (Nothing, Nothing) Nothing Nothing Nothing ])
+                                                    , Note Three A (Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
   , Test $ mkParseTest "b2<a3\n" (Chord 1 1 Nothing [ Note Two B (Nothing, Nothing) (Just $ OrnC (Just 2) Nothing) Nothing Nothing
-                                                    , Note Three A (Nothing, Nothing) Nothing Nothing Nothing ])
+                                                    , Note Three A (Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
   , Test $ mkParseTest "b2#a3\n" (Chord 1 1 Nothing [ Note Two B (Nothing, Nothing) (Just $ OrnE Nothing Nothing) Nothing Nothing
-                                                    , Note Three A (Nothing, Nothing) Nothing Nothing Nothing ])
+                                                    , Note Three A (Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
   , Test $ mkParseTest "b2xa3\n" (Chord 1 1 Nothing [ Note Two B (Nothing, Nothing) (Just $ OrnF Nothing Nothing) Nothing Nothing
-                                                    , Note Three A (Nothing, Nothing) Nothing Nothing Nothing ])
+                                                    , Note Three A (Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
   , Test $ mkParseTest "b2~a3\n" (Chord 1 1 Nothing [ Note Two B (Nothing, Nothing) (Just $ OrnH Nothing Nothing) Nothing Nothing
-                                                    , Note Three A (Nothing, Nothing) Nothing Nothing Nothing ])
+                                                    , Note Three A (Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
   , Test $ mkInvalidTest "b2(On)\n"
   , Test $ mkInvalidTest "b2(Oa)(Ob)\n"
   , Test $ mkInvalidTest "b2(Oa),\n"
@@ -342,16 +343,28 @@ ornaments =
 
 comments :: [Test]
 comments =
-  [ Test $ mkParseTest "{foo bar}\n" (Comment 1 1 "foo bar")
-  , Test $ mkParseTest "{foo {bar}\n" (Comment 1 1 "foo {bar")
-  , Test $ mkParseTest "{Qc1a2}" (Comment 1 1 "Qc1a2")
-  , Test $ mkParseTest "{}" (Comment 1 1 "")
-  , Test $ mkParseTest "{\n}" (Comment 1 1 "\n")
-  , Test $ mkParseTest "{foo\nbar}" (Comment 1 1 "foo\nbar")
-  , Test $ mkParseTest "{foo}a1c3" (Chord 1 1 Nothing [ Note One A (Nothing, Nothing) Nothing Nothing Nothing
-                                                      , Note Three C (Nothing, Nothing) Nothing Nothing Nothing ])
-  , Test $ mkParseTest "a1{foo}c3" (Chord 1 1 Nothing [ Note One A (Nothing, Nothing) Nothing Nothing Nothing
-                                                      , Note Three C (Nothing, Nothing) Nothing Nothing Nothing ])
+  [ Test $ mkParseTest "{foo bar}\n" (CommentWord 1 1 (Comment "foo bar"))
+  , Test $ mkParseTest "{foo {bar}\n" (CommentWord 1 1 (Comment "foo {bar"))
+  , Test $ mkParseTest "{Qc1a2}" (CommentWord 1 1 (Comment "Qc1a2"))
+  , Test $ mkParseTest "{}" (CommentWord 1 1 (Comment ""))
+  , Test $ mkParseTest "{\n}" (CommentWord 1 1 (Comment "\n"))
+  , Test $ mkParseTest "{foo\nbar}" (CommentWord 1 1 (Comment "foo\nbar"))
+  , Test $ mkParseTest "Q.{foo}" (Rest 1 1 (RhythmSign Crotchet Simple Dot Nothing) (Just $ Comment "foo"))
+  , Test $ mkParseTest "|{foo}" (BarLine 1 1 (SingleBar Nothing Nothing NotDashed Counting) (Just $ Comment "foo"))
+  , Test $ mkParseTest "M(3){foo}" (Meter 1 1 (SingleMeterSign (Beats 3)) (Just $ Comment "foo"))
   , Test $ mkParseTest "a1c3{foo}" (Chord 1 1 Nothing [ Note One A (Nothing, Nothing) Nothing Nothing Nothing
-                                                      , Note Three C (Nothing, Nothing) Nothing Nothing Nothing ])
+                                                      , Note Three C (Nothing, Nothing) Nothing Nothing Nothing ] (Just $ Comment "foo"))
+  , Test $ mkParseTest "a1c3 {foo}" (Chord 1 1 Nothing [ Note One A (Nothing, Nothing) Nothing Nothing Nothing
+                                                       , Note Three C (Nothing, Nothing) Nothing Nothing Nothing ] (Just $ Comment "foo"))
+  , Test $ mkParsePhraseTest "a1c3\n{foo}" [ (Chord 1 1 Nothing [ Note One A (Nothing, Nothing) Nothing Nothing Nothing
+                                                                , Note Three C (Nothing, Nothing) Nothing Nothing Nothing ] Nothing)
+                                           , (CommentWord 2 1 (Comment "foo")) ]
+  , Test $ mkParseTest "{^}{foo}" (SystemBreak 1 1 (Just $ Comment "foo"))
+  , Test $ mkParseTest "{>}{^}{foo}" (PageBreak 1 1 (Just $ Comment "foo"))
+  ]
+
+structuredComments :: [Test]
+structuredComments =
+  [ Test $ mkParseTest "{^}\n" (SystemBreak 1 1 Nothing)
+  , Test $ mkParseTest "{>}{^}\n" (PageBreak 1 1 Nothing)
   ]


### PR DESCRIPTION
Treat same-line comments as attached to the tabword. Allow attached comments to have no preceding whitespace.